### PR TITLE
Flag to ignore database interactions

### DIFF
--- a/MockProvider.cls
+++ b/MockProvider.cls
@@ -1,5 +1,6 @@
 @isTest
 public class MockProvider implements System.StubProvider {
+    public static Boolean ignoreDatabaseInteractions = false;
     public class MockProviderException extends Exception {}
     private static final Set<Type> INCONSTRUCTIBLE_TYPES = new Set<Type> {
         Date.class,


### PR DESCRIPTION
This is particularly useful with `QueryBuilder`, since this repo does not have a good way of dealing with Builders yet. Will probably need to bring `ConditionsManager` out of `QueryBuilder` for StubAPI to work